### PR TITLE
Enforce the full OpenPGP fingerprint of the Collabora repo

### DIFF
--- a/scripts/install-libreoffice.sh
+++ b/scripts/install-libreoffice.sh
@@ -11,7 +11,7 @@ apt-get -y install locales-all
 
 # Add Collabora repos
 echo "deb https://collaboraoffice.com/repos/CollaboraOnline/CODE /" >> /etc/apt/sources.list.d/collabora.list
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0C54D189F4BA284D
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6CCEA47B2281732DF5D504D00C54D189F4BA284D
 apt-get update
 
 # Install the Collabora packages


### PR DESCRIPTION
Previously, basically anyone in the position to MITM the network connection of the build server for this image could have compromised it.

Ref: https://github.com/kylemanna/docker-bitcoind/pull/43