### PR TITLE
Prevent collabora repository in sources.list

### DIFF
--- a/scripts/install-libreoffice.sh
+++ b/scripts/install-libreoffice.sh
@@ -10,7 +10,7 @@ apt-get -y install apt-transport-https
 apt-get -y install locales-all
 
 # Add Collabora repos
-echo "deb https://collaboraoffice.com/repos/CollaboraOnline/CODE /" >> /etc/apt/sources.list.d/collabora.list
+echo "deb https://collaboraoffice.com/repos/CollaboraOnline/CODE /" > /etc/apt/sources.list.d/collabora.list
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6CCEA47B2281732DF5D504D00C54D189F4BA284D
 apt-get update
 


### PR DESCRIPTION
Prevent collabora repository error if script is launched two time:
W: Target Packages (Packages) is configured multiple times in /etc/apt/sources.list.d/collabora.list

Signed-off-by: Alban Vidal alban.vidal@zordhak.fr