### PR TITLE
Expose the default port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,7 @@ ADD /scripts/install-libreoffice.sh /
 ADD /scripts/start-libreoffice.sh /
 RUN bash install-libreoffice.sh
 
+EXPOSE 9980
+
 # Entry point
 CMD bash start-libreoffice.sh


### PR DESCRIPTION
This will enable using this image inside a network or cluster without publishing the port to the outside world.