### PR TITLE
Added logging level, SSL and proxy parameters as configurable

### DIFF
--- a/scripts/start-libreoffice.sh
+++ b/scripts/start-libreoffice.sh
@@ -32,5 +32,10 @@ perl -pi -e "s/<password (.*)>.*<\/password>/<password \1>${password}<\/password
 perl -pi -e "s/<server_name (.*)>.*<\/server_name>/<server_name \1>${server_name}<\/server_name>/" /etc/loolwsd/loolwsd.xml
 perl -pi -e "s/<allowed_languages (.*)>.*<\/allowed_languages>/<allowed_languages \1>${dictionaries:-de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru}<\/allowed_languages>/" /etc/loolwsd/loolwsd.xml
 
+# Replace logging level, SSL and proxy activation 
+perl -pi -e "s/<level (.*)>.*<\/level>/<level \1>${logging}<\/level>/" /etc/loolwsd/loolwsd.xml
+perl -pi -e "s/<enable type(.*)>.*<\/enable>/<enable type\1>${ssl}<\/enable>/" /etc/loolwsd/loolwsd.xml
+perl -pi -e "s/<termination (.*)>.*<\/termination>/<termination \1>${proxy}<\/termination>/" /etc/loolwsd/loolwsd.xml
+
 # Start loolwsd
 su -c "/usr/bin/loolwsd --version --o:sys_template_path=/opt/lool/systemplate --o:lo_template_path=/opt/collaboraoffice5.3 --o:child_root_path=/opt/lool/child-roots --o:file_server_root_path=/usr/share/loolwsd" -s /bin/bash lool


### PR DESCRIPTION
Add 3 new parameters configurable at execution time:

- logging level (useful for debugging)
- SSL : in order to deactivate the use of SSL (for instance if running behind a proxy already providing SSL connectivity and managing certificates)
- proxy : to set whether or not this docker is running behind a proxy