### PR TITLE
Add env variable to permit running behind SSL-terminating reverse proxy

### DIFF
--- a/scripts/start-libreoffice.sh
+++ b/scripts/start-libreoffice.sh
@@ -25,6 +25,10 @@ mv certs/servers/localhost/cert.pem /etc/loolwsd/cert.pem
 mv certs/ca/root.crt.pem /etc/loolwsd/ca-chain.cert.pem
 fi
 
+# If we've passed the $termination env variable, apply it - useful when behind an SSL-terminating reverse proxy like traefik
+[[ -z "${termination}" ]] && APPLY_TERMINATION='false' || APPLY_TERMINATION="${termination}"
+perl -pi -e "s/<termination (.*)>.*<\/termination>/<termination \1>${APPLY_TERMINATION}<\/termination>/" /etc/loolwsd/loolwsd.xml
+
 # Replace trusted host and set admin username and password
 perl -pi -e "s/localhost<\/host>/${domain}<\/host>/g" /etc/loolwsd/loolwsd.xml
 perl -pi -e "s/<username (.*)>.*<\/username>/<username \1>${username}<\/username>/" /etc/loolwsd/loolwsd.xml


### PR DESCRIPTION
When trying to run Collabora behind an SSL-terminating reverse proxy (I used Traefik), it's necessary (and supported) to set "termination" to true, for the following:

```
Connection via proxy where loolwsd acts as working via https, but actually uses http
```

This was not possible using the current image, so I submit this patch which would allow user to pass "termination=true" environment variable (I used lower-case variable name to remain consistent with existing variables) so that this value is correctly set in loolwsd.xml